### PR TITLE
Clarify when the vote has concluded

### DIFF
--- a/src/main/scala/score/discord/generalbot/functionality/VoiceKick.scala
+++ b/src/main/scala/score/discord/generalbot/functionality/VoiceKick.scala
@@ -180,13 +180,13 @@ class VoiceKick(implicit messageOwnership: MessageOwnership, replyCache: ReplyCa
       else "The vote is currently in progress."
 
     if (!kickState.ended)
-    s"A vote to kick $targetMention from $chanMention has been called.\n" +
-      s"$usersWhoShouldVote, please vote for (${KickVote.emoji}) " +
-      s"or against (${StayVote.emoji}) the kick, " +
-      s"or abstain (${AbstainVote.emoji}) to exclude yourself from the vote.\n\n" +
+      s"A vote to kick $targetMention from $chanMention has been called.\n" +
+        s"$usersWhoShouldVote, please vote for (${KickVote.emoji}) " +
+        s"or against (${StayVote.emoji}) the kick, " +
+        s"or abstain (${AbstainVote.emoji}) to exclude yourself from the vote.\n\n" +
+        s"**Votes**: $votesSoFar\n$finalResult"
+    else s"A vote to kick $targetMention from $chanMention was called and has concluded.\n$usersWhoShouldVote\n\n" +
       s"**Votes**: $votesSoFar\n$finalResult"
-    else s"A vote to kick $targetMention from $chanMention was called and has concluded.\n\n**Votes**: $votesSoFar\n" +
-      s"$finalResult"
   }
 
   private def getEmojiMeaning(emoji: String): Option[VoteType] = emoji match {

--- a/src/main/scala/score/discord/generalbot/functionality/VoiceKick.scala
+++ b/src/main/scala/score/discord/generalbot/functionality/VoiceKick.scala
@@ -62,6 +62,8 @@ class VoiceKick(implicit messageOwnership: MessageOwnership, replyCache: ReplyCa
 
     // TODO: There is no actual expiry mechanic other than cosmetically
     def expired: Boolean = System.currentTimeMillis() >= expiry
+
+    def ended: Boolean = passed || failed || expired
   }
 
   private val pendingKicks = mutable.Map.empty[ID[Message], KickState]
@@ -177,15 +179,14 @@ class VoiceKick(implicit messageOwnership: MessageOwnership, replyCache: ReplyCa
       else if (kickState.expired) "The vote has timed out."
       else "The vote is currently in progress."
 
-    val strikethrough =
-      if (kickState.passed || kickState.failed || kickState.expired) "~~"
-      else ""
-
-    s"${strikethrough}A vote to kick $targetMention from $chanMention has been called.$strikethrough\n" +
-      s"$strikethrough$usersWhoShouldVote, please vote for (${KickVote.emoji}) " +
+    if (!kickState.ended)
+    s"A vote to kick $targetMention from $chanMention has been called.\n" +
+      s"$usersWhoShouldVote, please vote for (${KickVote.emoji}) " +
       s"or against (${StayVote.emoji}) the kick, " +
-      s"or abstain (${AbstainVote.emoji}) to exclude yourself from the vote.$strikethrough\n\n" +
+      s"or abstain (${AbstainVote.emoji}) to exclude yourself from the vote.\n\n" +
       s"**Votes**: $votesSoFar\n$finalResult"
+    else s"A vote to kick $targetMention from $chanMention was called and has concluded.\n\n**Votes**: $votesSoFar\n" +
+      s"$finalResult"
   }
 
   private def getEmojiMeaning(emoji: String): Option[VoteType] = emoji match {


### PR DESCRIPTION
Remove unnecessary information when the vote is over, making it clearer to see what the final result was. Also adds an "ended" method to the KickState class (which was notably missing)