### PR TITLE
Upgrade JDA from 5.0.0-beta.16 to 5.0.0, fix unit tests

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.17"
-  lazy val jda = ("net.dv8tion" % "JDA" % "5.0.0-beta.16")
+  lazy val jda = ("net.dv8tion" % "JDA" % "5.0.0")
     .exclude("net.java.dev.jna", "jna")
     .exclude("club.minnced", "opus-java-api")
     .exclude("club.minnced", "opus-java-natives")

--- a/src/test/scala/score/discord/canti/jdamocks/FakeGuild.scala
+++ b/src/test/scala/score/discord/canti/jdamocks/FakeGuild.scala
@@ -19,7 +19,7 @@ import net.dv8tion.jda.api.requests.restaction.order.{
 }
 import net.dv8tion.jda.api.requests.restaction.pagination.AuditLogPaginationAction
 import net.dv8tion.jda.api.utils.cache.{
-  MemberCacheView, SnowflakeCacheView, SortedSnowflakeCacheView
+  MemberCacheView, SnowflakeCacheView, SortedChannelCacheView, SortedSnowflakeCacheView
 }
 import net.dv8tion.jda.api.utils.concurrent.Task
 import net.dv8tion.jda.api.{JDA, Region}
@@ -50,7 +50,7 @@ import net.dv8tion.jda.api.entities.sticker.StickerSnowflake
 import java.time.temporal.TemporalAccessor
 import net.dv8tion.jda.api.managers.AutoModRuleManager
 import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel
-import java.time.OffsetDateTime
+import java.time.{Duration, OffsetDateTime}
 import net.dv8tion.jda.api.utils.FileUpload
 import net.dv8tion.jda.api.managers.GuildWelcomeScreenManager
 import net.dv8tion.jda.api.entities.automod.build.AutoModRuleData
@@ -103,6 +103,8 @@ class FakeGuild(val fakeJda: FakeJda, id: Long) extends Guild:
       },
       _.getName.nn
     )
+
+  override def getChannelCache: SortedChannelCacheView[GuildChannel] = ???
 
   override def getVoiceChannelCache: SortedSnowflakeCacheView[VoiceChannel] = ???
 
@@ -175,6 +177,11 @@ class FakeGuild(val fakeJda: FakeJda, id: Long) extends Guild:
   override def kick(member: UserSnowflake, reason: String): AuditableRestAction[Void] = ???
 
   override def ban(user: UserSnowflake, time: Int, unit: TimeUnit): AuditableRestAction[Void] = ???
+
+  override def ban(
+    users: util.Collection[? <: UserSnowflake],
+    deletionTimeframe: Duration
+  ): AuditableRestAction[BulkBanResponse] = ???
 
   override def unban(userId: UserSnowflake): AuditableRestAction[Void] = ???
 

--- a/src/test/scala/score/discord/canti/jdamocks/FakeJda.scala
+++ b/src/test/scala/score/discord/canti/jdamocks/FakeJda.scala
@@ -9,14 +9,16 @@ import net.dv8tion.jda.api.interactions.commands.build.CommandData
 import net.dv8tion.jda.api.managers.{AudioManager, DirectAudioController, Presence}
 import net.dv8tion.jda.api.requests.{GatewayIntent, RestAction}
 import net.dv8tion.jda.api.requests.restaction.{
-  CommandCreateAction, CommandEditAction, CommandListUpdateAction, GuildAction
+  CommandCreateAction, CommandEditAction, CommandListUpdateAction, GuildAction,
+  TestEntitlementCreateAction
 }
 import net.dv8tion.jda.api.sharding.ShardManager
-import net.dv8tion.jda.api.utils.cache.{CacheFlag, CacheView, SnowflakeCacheView}
+import net.dv8tion.jda.api.utils.cache.{CacheFlag, CacheView, ChannelCacheView, SnowflakeCacheView}
 import net.dv8tion.jda.api.{AccountType, JDA, Permission}
 import okhttp3.OkHttpClient
 
 import scala.jdk.CollectionConverters.*
+import net.dv8tion.jda.api.entities.channel.Channel
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import net.dv8tion.jda.api.entities.channel.concrete.Category
 import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel
@@ -28,6 +30,7 @@ import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel
 import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel
 import net.dv8tion.jda.api.entities.sticker.StickerPack
 import net.dv8tion.jda.api.requests.restaction.CacheRestAction
+import net.dv8tion.jda.api.requests.restaction.pagination.EntitlementPaginationAction
 import java.util as ju
 import net.dv8tion.jda.api.entities.channel.concrete.MediaChannel
 import net.dv8tion.jda.api.entities.sticker.StickerUnion
@@ -85,6 +88,15 @@ class FakeJda extends JDA:
         .groupBy(_.getIdLong)
         .view
         .mapValues(_.head)
+        .toMap,
+      _.getName.nn
+    )
+
+  override def getChannelCache: ChannelCacheView[Channel] =
+    ScalaChannelCacheView[Channel](
+      guilds.values
+        .flatMap(_.getTextChannels.nn.asScala)
+        .map(channel => channel.getIdLong -> channel.asInstanceOf[Channel])
         .toMap,
       _.getName.nn
     )
@@ -184,6 +196,18 @@ class FakeJda extends JDA:
   override def deleteCommandById(commandId: String): RestAction[Void] = ???
 
   override def setRequiredScopes(scopes: util.Collection[String]): JDA = ???
+
+  override def retrieveEntitlements(): EntitlementPaginationAction = ???
+
+  override def retrieveEntitlementById(id: Long): RestAction[Entitlement] = ???
+
+  override def createTestEntitlement(
+    skuId: Long,
+    ownerId: Long,
+    ownerType: TestEntitlementCreateAction.OwnerType | Null
+  ): TestEntitlementCreateAction = ???
+
+  override def deleteTestEntitlement(id: Long): RestAction[Void] = ???
 
   override def createGuildFromTemplate(code: String, name: String, icon: Icon): RestAction[Void] =
     ???

--- a/src/test/scala/score/discord/canti/jdamocks/FakeMessage.scala
+++ b/src/test/scala/score/discord/canti/jdamocks/FakeMessage.scala
@@ -1,20 +1,31 @@
 package score.discord.canti.jdamocks
 
+import java.time.OffsetDateTime
 import java.util
-import java.util.Collections
+import java.util.Formatter
 
 import net.dv8tion.jda.api.JDA
-import net.dv8tion.jda.api.entities.{Message, MessageActivity, MessageEmbed, User}
-import net.dv8tion.jda.internal.entities.AbstractMessage
+import net.dv8tion.jda.api.entities.*
+import net.dv8tion.jda.api.entities.channel.ChannelType
+import net.dv8tion.jda.api.entities.channel.concrete.{Category, ThreadChannel}
+import net.dv8tion.jda.api.entities.channel.unions.{GuildMessageChannelUnion, MessageChannelUnion}
+import net.dv8tion.jda.api.entities.messages.MessagePoll
 import score.discord.canti.SnowflakeOrdering
 
 import scala.jdk.CollectionConverters.*
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
-import net.dv8tion.jda.api.entities.sticker.Sticker
-import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion
 import net.dv8tion.jda.api.entities.sticker.StickerItem
-import net.dv8tion.jda.api.requests.restaction.MessageCreateAction
-import net.dv8tion.jda.api.utils.messages.MessageCreateData
+import net.dv8tion.jda.api.interactions.components.LayoutComponent
+import net.dv8tion.jda.api.entities.emoji.Emoji
+import net.dv8tion.jda.api.requests.RestAction
+import net.dv8tion.jda.api.requests.restaction.{
+  AuditableRestAction,
+  MessageEditAction,
+  ThreadChannelAction
+}
+import net.dv8tion.jda.api.requests.restaction.pagination.ReactionPaginationAction
+import net.dv8tion.jda.api.utils.AttachedFile
+import net.dv8tion.jda.api.utils.messages.MessageEditData
 
 class FakeMessage(
   channel: MessageChannel,
@@ -22,21 +33,54 @@ class FakeMessage(
   content: String,
   author: User | Null,
   embeds: util.List[MessageEmbed]
-) extends AbstractMessage(content, "dummy nonce", false)
+) extends Message
     with SnowflakeOrdering:
   override def getJumpUrl: String = s"https://dummy.jump.url/$id"
 
-  override def unsupported(): Unit = ???
+  override def getContentDisplay: String = content
+
+  override def getContentRaw: String = content
+
+  override def getContentStripped: String = content
+
+  override def getNonce: String = "dummy nonce"
 
   override def getChannel: MessageChannelUnion =
     channel.asInstanceOf[MessageChannelUnion]
 
+  override def getChannelType: ChannelType = channel.getType.nn
+
+  override def getChannelIdLong: Long = channel.getIdLong
+
+  override def hasChannel: Boolean = true
+
+  override def isFromType(channelType: ChannelType): Boolean = getChannelType == channelType
+
+  override def isFromGuild: Boolean = channel.getType.nn.isGuild
+
+  override def hasGuild: Boolean = isFromGuild
+
+  override def getGuild: Guild = getGuildChannel.getGuild.nn
+
+  override def getGuildIdLong: Long = getGuild.getIdLong
+
+  override def getGuildChannel: GuildMessageChannelUnion =
+    channel.asInstanceOf[GuildMessageChannelUnion]
+
+  override def getCategory: Category = ???
+
   override def getAuthor: User =
     author.nn // should not be called on a message that isn't "received"
+
+  override def getMember: Member = getGuild.getMember(getAuthor).nn
 
   override def getEmbeds: util.List[MessageEmbed] = embeds
 
   override def getAttachments: util.List[Message.Attachment] = Nil.asJava
+
+  override def getComponents: util.List[LayoutComponent] = Nil.asJava
+
+  override def getReactions: util.List[MessageReaction] = Nil.asJava
 
   override def getJDA: JDA = channel.getJDA.nn
 
@@ -47,3 +91,89 @@ class FakeMessage(
   override def getStickers: util.List[StickerItem] = Nil.asJava
 
   override def getApplicationIdLong(): Long = ???
+
+  override def getPoll(): MessagePoll = ???
+
+  override def endPoll(): AuditableRestAction[Message] = ???
+
+  override def getMessageReference: MessageReference = ???
+
+  override def getMentions: Mentions = ???
+
+  override def isEdited: Boolean = false
+
+  override def getTimeEdited: OffsetDateTime = ???
+
+  override def getApproximatePosition: Int = ???
+
+  override def getInvites: util.List[String] = Nil.asJava
+
+  override def isWebhookMessage: Boolean = false
+
+  override def isTTS: Boolean = false
+
+  override def editMessage(newContent: CharSequence): MessageEditAction = ???
+
+  override def editMessage(data: MessageEditData): MessageEditAction = ???
+
+  override def editMessageEmbeds(
+    embeds: util.Collection[? <: MessageEmbed]
+  ): MessageEditAction = ???
+
+  override def editMessageComponents(
+    components: util.Collection[? <: LayoutComponent]
+  ): MessageEditAction = ???
+
+  override def editMessageFormat(format: String, args: Object*): MessageEditAction = ???
+
+  override def editMessageAttachments(
+    attachments: util.Collection[? <: AttachedFile]
+  ): MessageEditAction = ???
+
+  override def delete(): AuditableRestAction[Void] = ???
+
+  override def isPinned: Boolean = false
+
+  override def pin(): RestAction[Void] = ???
+
+  override def unpin(): RestAction[Void] = ???
+
+  override def addReaction(emoji: Emoji): RestAction[Void] = ???
+
+  override def clearReactions(): RestAction[Void] = ???
+
+  override def clearReactions(emoji: Emoji): RestAction[Void] = ???
+
+  override def removeReaction(emoji: Emoji): RestAction[Void] = ???
+
+  override def removeReaction(emoji: Emoji, user: User): RestAction[Void] = ???
+
+  override def retrieveReactionUsers(emoji: Emoji): ReactionPaginationAction = ???
+
+  override def getReaction(emoji: Emoji): MessageReaction = ???
+
+  override def suppressEmbeds(suppressed: Boolean): AuditableRestAction[Void] = ???
+
+  override def crosspost(): RestAction[Message] = ???
+
+  override def isSuppressedEmbeds: Boolean = false
+
+  override def getFlags: util.EnumSet[Message.MessageFlag] =
+    util.EnumSet.noneOf(classOf[Message.MessageFlag]).nn
+
+  override def getFlagsRaw: Long = 0L
+
+  override def isEphemeral: Boolean = false
+
+  override def isSuppressedNotifications: Boolean = false
+
+  override def getStartedThread: ThreadChannel = ???
+
+  override def getType: MessageType = MessageType.DEFAULT
+
+  override def getInteraction: Message.Interaction = ???
+
+  override def createThreadChannel(name: String): ThreadChannelAction = ???
+
+  override def formatTo(formatter: Formatter, flags: Int, width: Int, precision: Int): Unit =
+    formatter.format(getJumpUrl)

--- a/src/test/scala/score/discord/canti/jdamocks/FakeMessageAction.scala
+++ b/src/test/scala/score/discord/canti/jdamocks/FakeMessageAction.scala
@@ -14,6 +14,7 @@ import net.dv8tion.jda.api.interactions.components.LayoutComponent
 import net.dv8tion.jda.api.entities.Message.MentionType
 import net.dv8tion.jda.api.entities.sticker.StickerSnowflake
 import net.dv8tion.jda.api.utils.FileUpload
+import net.dv8tion.jda.api.utils.messages.MessagePollData
 import java.util as ju
 
 class FakeMessageAction(message: Message) extends MessageCreateAction:
@@ -64,6 +65,10 @@ class FakeMessageAction(message: Message) extends MessageCreateAction:
     this // Not tracking files (yet)
 
   override def getComponents(): ju.List[LayoutComponent] | Null = ???
+
+  override def getPoll(): MessagePollData | Null = ???
+
+  override def setPoll(poll: MessagePollData | Null): MessageCreateAction | Null = ???
 
   override def getMentionedRoles(): ju.Set[String] | Null = ???
 

--- a/src/test/scala/score/discord/canti/jdamocks/FakeTextChannel.scala
+++ b/src/test/scala/score/discord/canti/jdamocks/FakeTextChannel.scala
@@ -53,7 +53,7 @@ class FakeTextChannel(guild: FakeGuild, id: Long, name: String)
       author = author,
       embeds = embeds
     )
-    cachedMessages += message.getIdLong -> message
+    cachedMessages = cachedMessages + (message.getIdLong -> message)
     lastMessage = message.getIdLong
     message
 

--- a/src/test/scala/score/discord/canti/jdamocks/ScalaChannelCacheView.scala
+++ b/src/test/scala/score/discord/canti/jdamocks/ScalaChannelCacheView.scala
@@ -1,0 +1,22 @@
+package score.discord.canti.jdamocks
+
+import net.dv8tion.jda.api.entities.channel.{Channel, ChannelType}
+import net.dv8tion.jda.api.utils.cache.ChannelCacheView
+
+class ScalaChannelCacheView[T <: Channel](
+  cache: collection.Map[Long, T],
+  getName: T => String
+) extends ScalaCacheView[T](cache.values, getName)
+    with ChannelCacheView[T]:
+  override def getElementById(id: Long): T | Null = cache.getOrElse(id, null)
+
+  override def getElementById(channelType: ChannelType, id: Long): T | Null =
+    cache.get(id).filter(_.getType == channelType).orNull
+
+  override def ofType[C <: T](clazz: Class[C]): ChannelCacheView[C] =
+    ScalaChannelCacheView[C](
+      cache.collect { case (id, channel) if clazz.isInstance(channel) =>
+        id -> clazz.cast(channel).nn
+      },
+      getName
+    )


### PR DESCRIPTION
Unit test fixes involved:
- Reimplementing most of the FakeMessage class since 5.0.0.beta-16 removed AbstractMessage
- Implementing just a few override methods for new parameters and methods in other classes

This JDA upgrade fixes a permissions bug on making new channels, where certain permissions (Use External Apps) didn't exist on the old version, so they were unable to be copied to new channels by Canti. 